### PR TITLE
Remove rpi-update line as it is no longer recommened

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ cd ~/catkin_ws
 rosdep install --from-paths src --ignore-src --rosdistro=kinetic -y
 ```
 
-Update your pi firmware using`rpi-update`.
-
 Compile the code with `catkin_make`.
 
 ## Running the Node


### PR DESCRIPTION
rpi-update is no longer recommended for non experimental purposes. The node runs fine on both kernel 4.1(old-stable) and 4.4(current stable), so this is completely unnecessary. 