### PR TITLE
Proper dependenices on the Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Download the source for this node by running
 
 `git clone https://github.com/UbiquityRobotics/raspicam_node.git`
 
+There are some dependencies that are not recognized by ros, so you need to create the file `/etc/ros/rosdep/sources.list.d/30-ubiquity.list` and add this to it.
+```
+yaml https://raw.githubusercontent.com/UbiquityRobotics/rosdep/master/raspberry-pi.yaml
+```
+
+Then run `rosdep update`.
+
 Install the ros dependencies, 
 
 ```

--- a/package.xml
+++ b/package.xml
@@ -4,10 +4,10 @@
   <version>0.1.0</version>
   <description>Package to access the Raspberry Pi Camera from ROS.</description>
 
-  <maintainer email="ra@ubiquityrobotics.com">Rohan Agrawal</maintainer>
+  <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
   <maintainer email="wayne@gramlich.net">Wayne Gramlich</maintainer>
 
-  <license>TODO</license>
+  <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>compressed_image_transport</depend>
@@ -15,6 +15,8 @@
   <depend>std_msgs</depend>
   <depend>camera_info_manager</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>libraspberrypi0</depend>
+  <build_depend>libraspberrypi-dev</build_depend>
 
   <export>
   </export>


### PR DESCRIPTION
This patch means that rosdep will ensure that all required dependencies are installed, but it also means that raspicam_node will not build on Intel due to not having all required dependencies.