### PR TITLE
Make raspicam_node write calibration to user writable location

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ A camera calibration can be run with the following commands:
 
     $ rosrun image_transport republish compressed in:=/raspicam_node/image raw out:=/raspicam_node/image
     $ rosrun camera_calibration cameracalibrator.py --size 8x6 --square 0.74 image:=/raspicam_node/image camera:=/raspicam_node
+    
+See http://wiki.ros.org/camera_calibration/Tutorials/MonocularCalibration for a guide on calibration
 
 By default the camera calibrations are saved in the 
 camera_info directory of this package.

--- a/camera_info/camerav1_1280x720.yaml
+++ b/camera_info/camerav1_1280x720.yaml
@@ -1,6 +1,6 @@
 image_width: 1280
 image_height: 720
-camera_name: camera
+camera_name: camerav1_1280x720
 camera_matrix:
   rows: 3
   cols: 3

--- a/camera_info/camerav2_1280x720.yaml
+++ b/camera_info/camerav2_1280x720.yaml
@@ -1,6 +1,6 @@
 image_width: 1280
 image_height: 720
-camera_name: camera
+camera_name: camerav2_1280x720
 camera_matrix:
   rows: 3
   cols: 3

--- a/camera_info/camerav2_1280x960.yaml
+++ b/camera_info/camerav2_1280x960.yaml
@@ -1,6 +1,6 @@
 image_width: 1280
 image_height: 960
-camera_name: camera
+camera_name: camerav2_1280x960
 camera_matrix:
   rows: 3
   cols: 3

--- a/camera_info/camerav2_410x308.yaml
+++ b/camera_info/camerav2_410x308.yaml
@@ -1,6 +1,6 @@
 image_width: 410
 image_height: 308
-camera_name: camera
+camera_name: camerav2_410x308
 camera_matrix:
   rows: 3
   cols: 3

--- a/launch/camerav1_1280x720.launch
+++ b/launch/camerav1_1280x720.launch
@@ -2,6 +2,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav1_1280x720.yaml"/>
+    <param name="camera_name" value="camerav1_1280x720"/>
     <param name="width" value="1280"/>
     <param name="height" value="720"/>
     <!-- We are running at 90fps to reduce motion blur -->

--- a/launch/camerav2_1280x720.launch
+++ b/launch/camerav2_1280x720.launch
@@ -2,6 +2,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
  
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_1280x720.yaml"/>
+    <param name="camera_name" value="camerav2_1280x720"/>
     <param name="width" value="1280"/>
     <param name="height" value="720"/>
     <!-- We are running at 90fps to reduce motion blur -->

--- a/launch/camerav2_1280x960.launch
+++ b/launch/camerav2_1280x960.launch
@@ -2,6 +2,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_1280x960.yaml"/>
+    <param name="camera_name" value="camerav2_1280x960"/>
     <param name="width" value="1280"/>
     <param name="height" value="960"/>
     <param name="framerate" value="30"/>

--- a/launch/camerav2_1280x960_10fps.launch
+++ b/launch/camerav2_1280x960_10fps.launch
@@ -2,6 +2,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_1280x960.yaml"/>
+    <param name="camera_name" value="camerav2_1280x960"/>
     <param name="width" value="1280"/>
     <param name="height" value="960"/>
 

--- a/launch/camerav2_410x308_30fps.launch
+++ b/launch/camerav2_410x308_30fps.launch
@@ -2,6 +2,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_410x308.yaml"/>
+    <param name="camera_name" value="camerav2_410x308"/>
     <param name="width" value="410"/>
     <param name="height" value="308"/>
 

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -906,7 +906,7 @@ int main(int argc, char **argv) {
         ROS_INFO("Camera successfully calibrated from default file");
     }
 
-    if (!c_info_man.loadCameraInfo()) {
+    if (!c_info_man.loadCameraInfo("")) {
         ROS_INFO("No device specifc calibration found");
     } else {
         c_info = c_info_man.getCameraInfo();

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -894,6 +894,7 @@ int main(int argc, char **argv) {
 
     camera_info_manager::CameraInfoManager c_info_man(n, camera_name,
                                                       camera_info_url);
+
     // get_status(&state_srv);
     init_cam(&state_srv);  // will need to figure out how to handle start and
                            // stop with dynamic reconfigure
@@ -902,7 +903,14 @@ int main(int argc, char **argv) {
         ROS_INFO("Calibration file missing. Camera not calibrated");
     } else {
         c_info = c_info_man.getCameraInfo();
-        ROS_INFO("Camera successfully calibrated");
+        ROS_INFO("Camera successfully calibrated from default file");
+    }
+
+    if (!c_info_man.loadCameraInfo()) {
+        ROS_INFO("No device specifc calibration found");
+    } else {
+        c_info = c_info_man.getCameraInfo();
+        ROS_INFO("Camera successfully calibrated from device specifc file");
     }
 
     image_pub =


### PR DESCRIPTION
Fixes #47 

This makes the `camera_info_manager` use the default location in ~/.ros/camera_info to save and load camera_info's after the default calibration (package location). 

This enables a user to just click save in the calibration program and have the calibration 'just work' from then on.
