### PR TITLE
Major Code Clean (Part 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ include_directories(include
   /opt/vc/include/interface/vmcs_host/linux
 )
 
+add_compile_options(-Wall -Wuseless-cast -Wformat-nonliteral)
+
 ## Declare a cpp executable
 add_executable(raspicam_node src/raspicam_node.cpp src/RaspiCamControl.cpp)
 

--- a/cfg/Camera.cfg
+++ b/cfg/Camera.cfg
@@ -10,11 +10,11 @@ gen.add("sharpness",            int_t,    0, "Sharpness",             0,  -100, 
 gen.add("brightness",           int_t,    0, "Brightness",           50,     0, 100)
 gen.add("saturation",           int_t,    0, "Saturation",            0,     0, 100)
 gen.add("ISO",                  int_t,    0, "ISO",                 400,   100, 1600)
-gen.add("exposureCompensation", int_t,    0, "exposureCompensation",  0,   -10, 10)
-gen.add("videoStabilisation",  bool_t,    0, "videoStabilisation",  False)
+gen.add("exposure_compensation", int_t,    0, "Exposure Compensation",  0,   -10, 10)
+gen.add("video_stabilisation",  bool_t,    0, "Video Stabilisation",  False)
 gen.add("vFlip",               bool_t,    0, "vFlip",  False)
 gen.add("hFlip",               bool_t,    0, "hFlip",  False)
-gen.add("shutterSpeed", int_t,    0, "shutterSpeed",  10000,   0, 100000)
+gen.add("shutter_speed",         int_t,    0, "Shutter Speed (us)",  0,   0, 100000)
 
 gen.add("zoom",       double_t, 0, "Digital zoom",  1.0, 1.0, 4.0)
 

--- a/include/mmal_cxx_helper.h
+++ b/include/mmal_cxx_helper.h
@@ -13,7 +13,7 @@ namespace mmal
 struct component_deleter {
   void operator()(MMAL_COMPONENT_T* ptr) const {
     if (ptr != nullptr) {
-      for (size_t i = 0; i < ptr->output_num; ++i){
+      for (size_t i = 0; i < ptr->output_num; ++i) {
         if (ptr->output[i] && ptr->output[i]->is_enabled) {
           mmal_port_disable(ptr->output[i]);
         }

--- a/include/mmal_cxx_helper.h
+++ b/include/mmal_cxx_helper.h
@@ -13,7 +13,7 @@ namespace mmal
 struct component_deleter {
   void operator()(MMAL_COMPONENT_T* ptr) const {
     if (ptr != nullptr) {
-      for (int i = 0; i < ptr->output_num; ++i){
+      for (size_t i = 0; i < ptr->output_num; ++i){
         if (ptr->output[i] && ptr->output[i]->is_enabled) {
           mmal_port_disable(ptr->output[i]);
         }

--- a/include/mmal_cxx_helper.h
+++ b/include/mmal_cxx_helper.h
@@ -13,6 +13,12 @@ namespace mmal
 struct component_deleter {
   void operator()(MMAL_COMPONENT_T* ptr) const {
     if (ptr != nullptr) {
+      for (int i = 0; i < ptr->output_num; ++i){
+        if (ptr->output[i] && ptr->output[i]->is_enabled) {
+          mmal_port_disable(ptr->output[i]);
+        }
+      }
+      mmal_component_disable(ptr);
       mmal_component_destroy(ptr);
     }
   }

--- a/include/mmal_cxx_helper.h
+++ b/include/mmal_cxx_helper.h
@@ -13,20 +13,25 @@ namespace mmal
 struct component_deleter {
   void operator()(MMAL_COMPONENT_T* ptr) const {
     if (ptr != nullptr) {
-    	mmal_component_destroy(ptr);
-  	}
+      mmal_component_destroy(ptr);
+    }
   }
 };
 typedef std::unique_ptr<MMAL_COMPONENT_T, component_deleter> component_ptr;
 
-
 struct connection_deleter {
   void operator()(MMAL_CONNECTION_T* ptr) const {
     if (ptr != nullptr) {
-    	mmal_connection_destroy(ptr);
-  	}
+      mmal_connection_destroy(ptr);
+    }
   }
 };
 typedef std::unique_ptr<MMAL_CONNECTION_T, connection_deleter> connection_ptr;
 
+void default_delete_pool(MMAL_POOL_T* ptr) {
+  if (ptr != nullptr) {
+    fprintf(stderr, "%s\n", "LEAKED POOL! you need to define your own deleter");
+  }
+}
+typedef std::unique_ptr<MMAL_POOL_T, std::function<void(MMAL_POOL_T*)>> pool_ptr;
 }

--- a/src/RaspiCamControl.cpp
+++ b/src/RaspiCamControl.cpp
@@ -370,7 +370,7 @@ static const char* unmap_xref(const int en, XREF_T* map, int num_refs) {
  * @return MMAL parameter matching the string, or the AUTO option if no match
  * found
  */
-/*static*/ MMAL_PARAM_AWBMODE_T awb_mode_from_string(const char* str) {
+MMAL_PARAM_AWBMODE_T awb_mode_from_string(const char* str) {
   int i = map_xref(str, awb_map, awb_map_size);
 
   if (i != -1)
@@ -402,7 +402,7 @@ MMAL_PARAM_IMAGEFX_T imagefx_mode_from_string(const char* str) {
  * @return MMAL parameter matching the string, or the AUTO option if no match
  * found
  */
-static MMAL_PARAM_EXPOSUREMETERINGMODE_T metering_mode_from_string(const char* str) {
+MMAL_PARAM_EXPOSUREMETERINGMODE_T metering_mode_from_string(const char* str) {
   int i = map_xref(str, metering_mode_map, metering_mode_map_size);
 
   if (i != -1)

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -251,8 +251,10 @@ static void encoder_buffer_callback(MMAL_PORT_T* port, MMAL_BUFFER_HEADER_T* buf
           msg.header.frame_id = camera_frame_id;
           msg.header.stamp = ros::Time::now();
           msg.format = "jpg";
-          msg.data.insert(msg.data.end(), pData->buffer[pData->frame & 1].get(),
-                          &(pData->buffer[pData->frame & 1].get()[pData->id]));
+          auto start = pData->buffer[pData->frame & 1].get();
+          auto end = &(pData->buffer[pData->frame & 1].get()[pData->id]);
+          msg.data.reserve(pData->id);
+          std::copy(start, end, std::back_inserter(msg.data));
           image_pub.publish(msg);
           c_info.header.seq = pData->frame;
           c_info.header.stamp = msg.header.stamp;

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -745,10 +745,10 @@ void reconfigure_callback(raspicam_node::CameraConfig& config, uint32_t level, R
   ROS_INFO("Reconfigure Request: contrast %d, sharpness %d, brightness %d, "
            "saturation %d, ISO %d, exposureCompensation %d,"
            " videoStabilisation %d, vFlip %d, hFlip %d,"
-           " zoom %.2f, exposure_mode %s, awb_mode %s",
+           " zoom %.2f, exposure_mode %s, awb_mode %s, shutter_speed %d",
            config.contrast, config.sharpness, config.brightness, config.saturation, config.ISO,
-           config.exposureCompensation, config.videoStabilisation, config.vFlip, config.hFlip, config.zoom,
-           config.exposure_mode.c_str(), config.awb_mode.c_str());
+           config.exposure_compensation, config.video_stabilisation, config.vFlip, config.hFlip, config.zoom,
+           config.exposure_mode.c_str(), config.awb_mode.c_str(), config.shutter_speed);
 
   if (!state.camera_component.get()) {
     ROS_WARN("camera_component not initialized");
@@ -775,10 +775,10 @@ void reconfigure_callback(raspicam_node::CameraConfig& config, uint32_t level, R
   raspicamcontrol_set_brightness(*state.camera_component, config.brightness);
   raspicamcontrol_set_saturation(*state.camera_component, config.saturation);
   raspicamcontrol_set_ISO(*state.camera_component, config.ISO);
-  raspicamcontrol_set_exposure_compensation(*state.camera_component, config.exposureCompensation);
-  raspicamcontrol_set_video_stabilisation(*state.camera_component, config.videoStabilisation);
+  raspicamcontrol_set_exposure_compensation(*state.camera_component, config.exposure_compensation);
+  raspicamcontrol_set_video_stabilisation(*state.camera_component, config.video_stabilisation);
   raspicamcontrol_set_flips(*state.camera_component, config.hFlip, config.vFlip);
-  raspicamcontrol_set_shutter_speed(*state.camera_component, config.shutterSpeed);
+  raspicamcontrol_set_shutter_speed(*state.camera_component, config.shutter_speed);
 
   ROS_INFO("Reconfigure done");
 }

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -26,27 +26,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/**
- * \file RaspiVid.c
- * Command line program to capture a camera video stream and encode it to file.
- * Also optionally display a preview/viewfinder of current camera input.
- *
- * \date 28th Feb 2013
- * \Author: James Hughes
- *
- * Description
- *
- * 3 components are created; camera, preview and video encoder.
- * Camera component has three ports, preview, video and stills.
- * This program connects preview and stills to the preview and video
- * encoder. Using mmal we don't need to worry about buffers between these
- * components, but we do need to handle buffers from the encoder, which
- * are simply written straight to the file in the requisite buffer callback.
- *
- * We use the RaspiCamControl code to handle the specific camera settings.
- * We use the RaspiPreview code to handle the (generic) preview window
- */
-
 #ifdef __x86_64__
 
 #include <stdio.h>
@@ -111,8 +90,6 @@ const int IMG_BUFFER_SIZE = 10 * 1024 * 1024;  // 10 MB
 
 /// Video render needs at least 2 buffers.
 #define VIDEO_OUTPUT_BUFFERS_NUM 3
-
-int mmal_status_to_int(MMAL_STATUS_T status);
 
 /** Structure containing all state information for the current run
  */
@@ -572,33 +549,6 @@ static MMAL_STATUS_T connect_ports(MMAL_PORT_T* output_port, MMAL_PORT_T* input_
 }
 
 /**
- * Checks if specified port is valid and enabled, then disables it
- *
- * @param port  Pointer the port
- *
- */
-static void check_disable_port(MMAL_PORT_T* port) {
-  if (port && port->is_enabled)
-    mmal_port_disable(port);
-}
-
-/**
- * Handler for sigint signals
- *
- * @param signal_number ID of incoming signal.
- *
- */
-static void signal_handler(int signal_number) {
-  // Going to abort on all signals
-  vcos_log_error("Aborting program\n");
-  ROS_ERROR("Aborting program\n");
-
-  // TODO : Need to close any open stuff...how?
-
-  exit(255);
-}
-
-/**
  * init_cam
 
  */
@@ -614,8 +564,6 @@ int init_cam(RASPIVID_STATE& state) {
   bcm_host_init();
   // Register our application with the logging system
   vcos_log_register("RaspiVid", VCOS_LOG_CATEGORY);
-
-  signal(SIGINT, signal_handler);
 
   // OK, we have a nice set of parameters. Now set up our components
   // We have three components. Camera, Preview and encoder.
@@ -820,7 +768,7 @@ int main(int argc, char** argv) {
   start_capture(state_srv);
   ros::spin();
   close_cam(state_srv);
-  return 0;
+  ros::shutdown();
 }
 
 #endif  // __arm__

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -642,34 +642,20 @@ int close_cam(RASPIVID_STATE& state) {
     state.isInit = false;
     MMAL_COMPONENT_T* camera = state.camera_component.get();
     MMAL_COMPONENT_T* encoder = state.encoder_component.get();
-    MMAL_PORT_T* encoder_output_port = state.encoder_component->output[0];
-    MMAL_PORT_T* camera_still_port = camera->output[MMAL_CAMERA_CAPTURE_PORT];
-    PORT_USERDATA* pData = encoder_output_port->userdata;
 
-    if (camera_still_port && camera_still_port->is_enabled)
-      mmal_port_disable(camera_still_port);
-
-    if (encoder->output[0] && encoder->output[0]->is_enabled)
-      mmal_port_disable(encoder->output[0]);
-
+    // Destroy encoder port connection
     state.encoder_connection.reset(nullptr);
 
-    // Disable components
-    if (encoder)
-      mmal_component_disable(encoder);
-
-    if (camera)
-      mmal_component_disable(camera);
-
+    // Destroy encoder component
     if (encoder) {
-      // Destroy encoder component
       // Get rid of any port buffers first
       state.encoder_pool.reset(nullptr);
       state.video_pool.reset(nullptr);
       // Delete callback structure
-      delete pData;
+      delete encoder->output[0]->userdata;
       state.encoder_component.reset(nullptr);
     }
+
     // destroy camera component
     if (camera) {
       state.camera_component.reset(nullptr);


### PR DESCRIPTION
* Use unique_ptr[] for buffers instead of malloc
* Make a pool_ptr that supports clean deletion
* More references :+1: , less pointers :-1: 
* Cleanup dynamic reconfigure. Should fix #31 and fix #40 
* Slight perf improvement by reserving vector beforehand and using std::copy
* Better use of types (less casting)

Tested as working