### PR TITLE
Add support for motion vectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   camera_info_manager
   dynamic_reconfigure
+  message_generation
 )
 
 ## System dependencies are found with CMake's conventions
@@ -64,11 +65,10 @@ ENDIF()
 #######################################
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+  FILES
+  MotionVectors.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -78,10 +78,10 @@ ENDIF()
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 #add dynamic reconfigure api
 generate_dynamic_reconfigure_options(
@@ -102,6 +102,7 @@ catkin_package(
 #  LIBRARIES raspicam
 #  CATKIN_DEPENDS compressed_image_transport roscpp std_msgs
 #  DEPENDS system_lib
+   CATKIN_DEPENDS message_runtime std_msgs
 )
 
 ###########

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,7 @@ add_compile_options(-Wall -Wuseless-cast -Wformat-nonliteral)
 add_executable(raspicam_node src/raspicam_node.cpp src/RaspiCamControl.cpp)
 
 ## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(raspicam_node raspicam_generate_messages_cpp)
+add_dependencies(raspicam_node raspicam_node_generate_messages_cpp)
 add_dependencies(raspicam_node raspicam_node_gencfg)
 
 ## Specify libraries to link a library or executable target against

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Topics:
 * `/raspicam_node/image`:
   Publishes `sensor_msgs/Image` from the camera module (if parameter `enable_raw` is set).
 
+* `/raspicam_node/motion_vectors`:
+  Publishes `raspicam_node/MotionVectors` from the camera module (if parameter `enable_imv` is set).
+
 * `/raspicam_node/camera_info`:
   Publishes `sensor_msgs/CameraInfo` camera info for each frame.
 
@@ -100,6 +103,8 @@ Parameters:
 * `quality` (0-100): Quality of the captured images.
 
 * `enable_raw` (bool): Publish a raw image (takes more CPU and memory)
+
+* `enable_imv` (bool): Publish inline motion vectors computed by the GPU
 
 * `camera_id` (int): The camera id (only supported on Compute Module)
 

--- a/README.md
+++ b/README.md
@@ -155,14 +155,11 @@ On your workstation, build raspicam_node so that the `MotionVectors` ROS message
 ```
 cd ~/catkin_ws
 catkin_make
-catkin_make install
-
-source ~/.bashrc/devel/setup.bash
+source ~/catkin_ws/devel/setup.bash
 ```
 
 Finally, run script `raspicam_view.py` to visualize the motion vectors:
 
 ```
-cd raspicam_node/tools
-./raspicam_view.py
+rosrun raspicam_node raspicam_view.py
 ```

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ make sure that the camera cable is properly seated on both ends, and that the ca
 
 Topics:
 
-* `/raspicam_node/compressed`:
+* `/raspicam_node/image/compressed`:
   Publishes `sensor_msgs/CompressedImage` with jpeg from the camera module.
+
+* `/raspicam_node/image`:
+  Publishes `sensor_msgs/Image` from the camera module (if parameter `enable_raw` is set).
 
 * `/raspicam_node/camera_info`:
   Publishes `sensor_msgs/CameraInfo` camera info for each frame.

--- a/README.md
+++ b/README.md
@@ -139,3 +139,30 @@ On your workstation:
 ```
 rosrun camera_calibration cameracalibrator.py --size 8x6 --square 0.074 image:=/raspicam_node/image camera:=/raspicam_node
 ```
+
+## Motion vectors
+
+The raspicam_node is able to output [motion vectors](https://www.raspberrypi.org/blog/vectors-from-coarse-motion-estimation/) calculated by the Raspberry Pi's hardware video encoder. These motion vectors can be used for various applications such as motion detection.
+
+On the Pi, add `enable_imv:=true` to the camera roslaunch command:
+
+```
+roslaunch raspicam_node camerav2_410x308_30fps.launch enable_imv:=true
+```
+
+On your workstation, build raspicam_node so that the `MotionVectors` ROS message is recognized by Python:
+
+```
+cd ~/catkin_ws
+catkin_make
+catkin_make install
+
+source ~/.bashrc/devel/setup.bash
+```
+
+Finally, run script `raspicam_view.py` to visualize the motion vectors:
+
+```
+cd raspicam_node/tools
+./raspicam_view.py
+```

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ catkin_make
 source ~/catkin_ws/devel/setup.bash
 ```
 
-Finally, run script `raspicam_view.py` to visualize the motion vectors:
+Finally, run script `imv_view.py` to visualize the motion vectors:
 
 ```
-rosrun raspicam_node raspicam_view.py
+rosrun raspicam_node imv_view.py
 ```

--- a/launch/camerav1_1280x720.launch
+++ b/launch/camerav1_1280x720.launch
@@ -1,5 +1,6 @@
 <launch>
 	<arg name="enable_raw" default="false"/>
+  <arg name="enable_imv" default="false"/>
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav1_1280x720"/>
@@ -7,6 +8,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
   	<param name="camera_frame_id" value="$(arg camera_frame_id)"/> 
   	<param name="enable_raw" value="$(arg enable_raw)"/> 
+    <param name="enable_imv" value="$(arg enable_imv)"/>
     <param name="camera_id" value="$(arg camera_id)"/> 
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav1_1280x720.yaml"/>

--- a/launch/camerav2_1280x720.launch
+++ b/launch/camerav2_1280x720.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="enable_raw" default="false"/>
+  <arg name="enable_imv" default="false"/>
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_1280x720"/>
@@ -7,6 +8,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
   	<param name="camera_frame_id" value="$(arg camera_frame_id)"/>  
   	<param name="enable_raw" value="$(arg enable_raw)"/>
+    <param name="enable_imv" value="$(arg enable_imv)"/>
     <param name="camera_id" value="$(arg camera_id)"/> 
  
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_1280x720.yaml"/>

--- a/launch/camerav2_1280x960.launch
+++ b/launch/camerav2_1280x960.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="enable_raw" default="false"/>
+  <arg name="enable_imv" default="false"/>
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_1280x960"/>
@@ -7,6 +8,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
   	<param name="camera_frame_id" value="$(arg camera_frame_id)"/>  
   	<param name="enable_raw" value="$(arg enable_raw)"/>
+    <param name="enable_imv" value="$(arg enable_imv)"/>
     <param name="camera_id" value="$(arg camera_id)"/> 
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_1280x960.yaml"/>

--- a/launch/camerav2_1280x960_10fps.launch
+++ b/launch/camerav2_1280x960_10fps.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="enable_raw" default="false"/>
+  <arg name="enable_imv" default="false"/>
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_1280x960"/>
@@ -7,6 +8,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
     <param name="camera_frame_id" value="$(arg camera_frame_id)"/>  
     <param name="enable_raw" value="$(arg enable_raw)"/>
+    <param name="enable_imv" value="$(arg enable_imv)"/>
     <param name="camera_id" value="$(arg camera_id)"/> 
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_1280x960.yaml"/>

--- a/launch/camerav2_410x308_30fps.launch
+++ b/launch/camerav2_410x308_30fps.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="enable_raw" default="false"/>
+  <arg name="enable_imv" default="false"/>
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_410x308"/>
@@ -7,6 +8,7 @@
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
     <param name="camera_frame_id" value="$(arg camera_frame_id)"/> 
     <param name="enable_raw" value="$(arg enable_raw)"/>
+    <param name="enable_imv" value="$(arg enable_imv)"/>
     <param name="camera_id" value="$(arg camera_id)"/> 
 
     <param name="camera_info_url" value="package://raspicam_node/camera_info/camerav2_410x308.yaml"/>

--- a/msg/MotionVectors.msg
+++ b/msg/MotionVectors.msg
@@ -1,0 +1,17 @@
+# Message header
+std_msgs/Header header
+
+# Number of macroblocks in horizontal dimension
+uint8 mbx
+
+# Number of macroblocks in vertical dimension
+uint8 mby
+
+# Horizontal component of motion vectors
+int8[] x
+
+# Vertical component of motion vectors
+int8[] y
+
+# Sum of Absolute Difference metric of motion vectors
+uint16[] sad

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <depend>dynamic_reconfigure</depend>
   <depend>libraspberrypi0</depend>
   <build_depend>libraspberrypi-dev</build_depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
 
   <export>
   </export>

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -326,7 +326,7 @@ static void video_encoder_buffer_callback(MMAL_PORT_T* port, MMAL_BUFFER_HEADER_
       int8_t x;
       int8_t y;
       uint16_t sad;
-    } *imv = (struct imv *)buffer->data;
+    } *imv = reinterpret_cast<struct imv *>(buffer->data);
 
     size_t num_elements = buffer->length / sizeof(struct imv);
     motion_vectors.msg.x.resize(num_elements);

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
 #include "sensor_msgs/Image.h"
 #include "sensor_msgs/SetCameraInfo.h"
 #include "std_srvs/Empty.h"
-#include "raspicam_node/MotionVector.h"
+#include "raspicam_node/MotionVectors.h"
 
 #include "RaspiCamControl.h"
 
@@ -156,7 +156,7 @@ static CompressedImagePublisher compressed_image;
 
 struct MotionVectorsPublisher {
   ros::Publisher pub;
-  raspicam_node::MotionVector msg;
+  raspicam_node::MotionVectors msg;
 };
 
 static MotionVectorsPublisher motion_vectors;
@@ -1340,7 +1340,7 @@ int main(int argc, char** argv) {
     image.pub = n.advertise<sensor_msgs::Image>("image/", 1);
   }
   if (state_srv.enable_imv_pub) {
-    motion_vectors.pub = n.advertise<raspicam_node::MotionVector>("motion_vectors", 1);
+    motion_vectors.pub = n.advertise<raspicam_node::MotionVectors>("motion_vectors", 1);
   }
   compressed_image.pub = n.advertise<sensor_msgs::CompressedImage>("image/compressed", 1);
   camera_info_pub = n.advertise<sensor_msgs::CameraInfo>("camera_info", 1);

--- a/tools/imv_view.py
+++ b/tools/imv_view.py
@@ -60,7 +60,7 @@ def img_callback(msg):
 	else:
 		if last_imv is not None:
 			draw_imv(img, last_imv)
-		cv2.imshow('raspicam_node viewer', img)
+		cv2.imshow('raspicam_node motion vectors visualization', img)
 		cv2.waitKey(25)
 
 def imv_callback(msg):
@@ -74,7 +74,7 @@ def main():
 	img_topic = '/raspicam_node/image/compressed'
 	imv_topic = '/raspicam_node/motion_vectors'
 
-	rospy.init_node('raspicam_view')
+	rospy.init_node('imv_view')
 	rospy.Subscriber(img_topic, CompressedImage, img_callback)
 	rospy.Subscriber(imv_topic, MotionVectors, imv_callback)
 	rospy.spin()

--- a/tools/raspicam_view.py
+++ b/tools/raspicam_view.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+
+import rospy
+import math
+import struct
+import numpy as np
+import cv2
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import UInt8MultiArray
+from cv_bridge import CvBridge, CvBridgeError
+
+# Motion vectors with SAD values above threshold will be ignored:
+SAD_THRESHOLD = 650
+
+bridge = CvBridge()
+color_map = None
+last_imv = None
+
+def create_colormap(num_elements):
+	size = ( num_elements, 1, 1 )
+	im = np.zeros(size, dtype=np.uint8)
+
+	for i in range(0, num_elements):
+		im[i,0,0] = i
+
+	return cv2.applyColorMap(im, cv2.COLORMAP_JET)
+
+def draw_imv(img, imv):
+	height, width, channels = img.shape
+	mbx = int(math.ceil(width/16.0))
+	mby = int(math.ceil(height/16.0))
+
+	if len(imv.data) != (mbx + 1) * mby * 4:
+		print('Error: Wrong IMV size!')
+		return
+
+	# Draw colored arrow per each macroblock:
+	for j in range(0, mby):
+		for i in range(0, mbx):
+			idx = (i + (mbx + 1) * j) * 4
+			buff = imv.data[idx:idx+4]
+			dx, dy, sad = struct.unpack('<bbH', buff)
+
+			x = i*16 + 8;
+			y = j*16 + 8;
+
+			if dx == 0 and dy == 0:
+				continue
+
+			if sad >= SAD_THRESHOLD:
+				continue
+
+			color = ( int(color_map[sad,0,0]),
+					  int(color_map[sad,0,1]),
+					  int(color_map[sad,0,2]) )
+			cv2.arrowedLine(img, (x+dx, y+dy), (x, y), color, 1)
+
+def img_callback(msg):
+	try:
+		img = bridge.compressed_imgmsg_to_cv2(msg, 'bgr8')
+	except CvBridgeError as e:
+		print(e)
+	else:
+		if last_imv is not None:
+			draw_imv(img, last_imv)
+		cv2.imshow('raspicam_node viewer', img)
+		cv2.waitKey(25)
+
+def imv_callback(msg):
+	global last_imv
+	last_imv = msg
+
+def main():
+	global color_map
+	color_map = create_colormap(SAD_THRESHOLD)
+
+	img_topic = '/raspicam_node/image/compressed'
+	imv_topic = '/raspicam_node/motion_vectors'
+
+	rospy.init_node('raspicam_view')
+	rospy.Subscriber(img_topic, CompressedImage, img_callback)
+	rospy.Subscriber(imv_topic, UInt8MultiArray, imv_callback)
+	rospy.spin()
+
+if __name__ == '__main__':
+	main()

--- a/tools/raspicam_view.py
+++ b/tools/raspicam_view.py
@@ -6,7 +6,7 @@ import struct
 import numpy as np
 import cv2
 from sensor_msgs.msg import CompressedImage
-from std_msgs.msg import UInt8MultiArray
+from raspicam_node.msg import MotionVectors
 from cv_bridge import CvBridge, CvBridgeError
 
 # Motion vectors with SAD values above threshold will be ignored:
@@ -30,16 +30,13 @@ def draw_imv(img, imv):
 	mbx = int(math.ceil(width/16.0))
 	mby = int(math.ceil(height/16.0))
 
-	if len(imv.data) != (mbx + 1) * mby * 4:
-		print('Error: Wrong IMV size!')
-		return
-
 	# Draw colored arrow per each macroblock:
-	for j in range(0, mby):
-		for i in range(0, mbx):
-			idx = (i + (mbx + 1) * j) * 4
-			buff = imv.data[idx:idx+4]
-			dx, dy, sad = struct.unpack('<bbH', buff)
+	for j in range(0, imv.mby):
+		for i in range(0, imv.mbx):
+			idx = (i + (imv.mbx + 1) * j)
+			dx = imv.x[idx]
+			dy = imv.y[idx]
+			sad = imv.sad[idx]
 
 			x = i*16 + 8;
 			y = j*16 + 8;
@@ -79,7 +76,7 @@ def main():
 
 	rospy.init_node('raspicam_view')
 	rospy.Subscriber(img_topic, CompressedImage, img_callback)
-	rospy.Subscriber(imv_topic, UInt8MultiArray, imv_callback)
+	rospy.Subscriber(imv_topic, MotionVectors, imv_callback)
 	rospy.spin()
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds support for [motion vectors](https://www.raspberrypi.org/blog/vectors-from-coarse-motion-estimation/) produced by the coarse motion estimation block in the VideoCore GPU. When parameter `enable_imv` is set to true, the motion vectors are published at `/raspicam_node/motion_vectors`.

![imv](https://user-images.githubusercontent.com/4582325/49340717-3ad44900-f644-11e8-80ef-eb32c593c872.png)