### PR TITLE
Stop the frame rate from being divided by 3

### DIFF
--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
 static constexpr int IMG_BUFFER_SIZE = 10 * 1024 * 1024;  // 10 MB
 
 // Video format information
-static constexpr int VIDEO_FRAME_RATE_DEN = 3;
+static constexpr int VIDEO_FRAME_RATE_DEN = 1;
 
 // Video render needs at least 2 buffers.
 static constexpr int VIDEO_OUTPUT_BUFFERS_NUM = 3;


### PR DESCRIPTION
- Video frame rate denominator is now 1 instead of 3,
- Fixes #61 

Thanks to everyone who reported and confirmed this bug.