### PR TITLE
change compressed image format to acceptable value

### DIFF
--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -256,7 +256,7 @@ static void image_encoder_buffer_callback(MMAL_PORT_T* port, MMAL_BUFFER_HEADER_
           compressed_image.msg.header.seq = pData->frame;
           compressed_image.msg.header.frame_id = camera_frame_id;
           compressed_image.msg.header.stamp = ros::Time::now();
-          compressed_image.msg.format = "jpg";
+          compressed_image.msg.format = "jpeg";
           auto start = pData->buffer[pData->frame & 1].get();
           auto end = &(pData->buffer[pData->frame & 1].get()[pData->id]);
           compressed_image.msg.data.resize(pData->id);


### PR DESCRIPTION
When I tried to view the stream using [web_video_server](http://wiki.ros.org/web_video_server), I got these warning messages:

```
Unknown ROS compressed image format: jpg
```

[CompressedImage Message documentation ](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/CompressedImage.html) specifies acceptable format values to be `jpeg` or `png`. 

So I had to change the format to `jpeg` instead of `jpg`