### PR TITLE
fix compilation on aarch64 (e.g. Ubuntu 18.04.4 on Raspberry Pi 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(raspicam_node)
 
 
 set(CMAKE_CXX_STANDARD 14) # use C++14
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed")  # https://github.com/raspberrypi/userland/issues/178
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/src/RaspiCamControl.cpp
+++ b/src/RaspiCamControl.cpp
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 
 #include <memory.h>
 #include <stdio.h>
@@ -919,4 +919,4 @@ void raspicamcontrol_check_configuration(int min_gpu_mem) {
     vcos_log_error("Failed to run camera app. Please check for firmware updates\n");
 }
 
-#endif  // __arm__
+#endif  // __arm__ || __aarch64__

--- a/src/raspicam_node.cpp
+++ b/src/raspicam_node.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
 
 #endif  // __x86_64__
 
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 
 // We use some GNU extensions (basename)
 #include <memory.h>
@@ -1380,4 +1380,4 @@ int main(int argc, char** argv) {
   ros::shutdown();
 }
 
-#endif  // __arm__
+#endif  // __arm__ || __aarch64__


### PR DESCRIPTION
Tested on
```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.4 LTS
Release:        18.04
Codename:       bionic
```
with `userland` at 6e6a2c859a17a195fbb6a97c9da584dd2b9b0178 compiled using `./buildme --aarch64`
on Raspberry Pi 4.