### PR TITLE
Remove compressed_image_transport dependency from package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed")  # https://github.com/raspberry
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  compressed_image_transport
   roscpp
   std_msgs
   camera_info_manager
@@ -102,7 +101,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
    INCLUDE_DIRS include
 #  LIBRARIES raspicam
-#  CATKIN_DEPENDS compressed_image_transport roscpp std_msgs
+#  CATKIN_DEPENDS roscpp std_msgs
 #  DEPENDS system_lib
    CATKIN_DEPENDS message_runtime std_msgs
 )

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>compressed_image_transport</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>


### PR DESCRIPTION
compressed_image_transport is not needed since the camera images
are already compressed from the camera. sensor_msgs is sufficient.