### PR TITLE
added hFlip and vFlip params to launch files

### DIFF
--- a/launch/camerav1_1280x720.launch
+++ b/launch/camerav1_1280x720.launch
@@ -4,10 +4,15 @@
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav1_1280x720"/>
+  <arg name="vFlip" default="false"/>
+  <arg name="hFlip" default="false"/>
+
 
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
     <param name="private_topics" value="true"/>
 
+    <param name="vFlip" value="$(arg vFlip)"/>
+    <param name="hFlip" value="$(arg hFlip)"/>
     <param name="camera_frame_id" value="$(arg camera_frame_id)"/>
     <param name="enable_raw" value="$(arg enable_raw)"/>
     <param name="enable_imv" value="$(arg enable_imv)"/>

--- a/launch/camerav2_1280x720.launch
+++ b/launch/camerav2_1280x720.launch
@@ -4,10 +4,14 @@
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_1280x720"/>
+  <arg name="vFlip" default="false"/>
+  <arg name="hFlip" default="false"/>
 
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
     <param name="private_topics" value="true"/>
 
+    <param name="vFlip" value="$(arg vFlip)"/>
+    <param name="hFlip" value="$(arg hFlip)"/>
     <param name="camera_frame_id" value="$(arg camera_frame_id)"/>
     <param name="enable_raw" value="$(arg enable_raw)"/>
     <param name="enable_imv" value="$(arg enable_imv)"/>

--- a/launch/camerav2_1280x960.launch
+++ b/launch/camerav2_1280x960.launch
@@ -4,10 +4,14 @@
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_1280x960"/>
+  <arg name="vFlip" default="false"/>
+  <arg name="hFlip" default="false"/>
 
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
     <param name="private_topics" value="true"/>
 
+    <param name="vFlip" value="$(arg vFlip)"/>
+    <param name="hFlip" value="$(arg hFlip)"/>
     <param name="camera_frame_id" value="$(arg camera_frame_id)"/>
     <param name="enable_raw" value="$(arg enable_raw)"/>
     <param name="enable_imv" value="$(arg enable_imv)"/>

--- a/launch/camerav2_1280x960_10fps.launch
+++ b/launch/camerav2_1280x960_10fps.launch
@@ -4,10 +4,14 @@
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_1280x960"/>
+  <arg name="vFlip" default="false"/>
+  <arg name="hFlip" default="false"/>
 
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
     <param name="private_topics" value="true"/>
 
+    <param name="vFlip" value="$(arg vFlip)"/>
+    <param name="hFlip" value="$(arg hFlip)"/>
     <param name="camera_frame_id" value="$(arg camera_frame_id)"/>
     <param name="enable_raw" value="$(arg enable_raw)"/>
     <param name="enable_imv" value="$(arg enable_imv)"/>

--- a/launch/camerav2_1640x1232_10fps.launch
+++ b/launch/camerav2_1640x1232_10fps.launch
@@ -3,9 +3,13 @@
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_1640x1232"/>
+  <arg name="vFlip" default="false"/>
+  <arg name="hFlip" default="false"/>
 
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
-    <param name="camera_frame_id" value="$(arg camera_frame_id)"/>  
+    <param name="vFlip" value="$(arg vFlip)"/>
+    <param name="hFlip" value="$(arg hFlip)"/>
+    <param name="camera_frame_id" value="$(arg camera_frame_id)"/>
     <param name="enable_raw" value="$(arg enable_raw)"/>
     <param name="camera_id" value="$(arg camera_id)"/> 
 

--- a/launch/camerav2_410x308_30fps.launch
+++ b/launch/camerav2_410x308_30fps.launch
@@ -4,10 +4,15 @@
   <arg name="camera_id" default="0"/>
   <arg name="camera_frame_id" default="raspicam"/>
   <arg name="camera_name" default="camerav2_410x308"/>
+  <arg name="vFlip" default="false"/>
+  <arg name="hFlip" default="false"/>
+
 
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
     <param name="private_topics" value="true"/>
 
+    <param name="vFlip" value="$(arg vFlip)"/>
+    <param name="hFlip" value="$(arg hFlip)"/>
     <param name="camera_frame_id" value="$(arg camera_frame_id)"/>
     <param name="enable_raw" value="$(arg enable_raw)"/>
     <param name="enable_imv" value="$(arg enable_imv)"/>


### PR DESCRIPTION
Added hFlip and vFlip parameters to launch files. These these parameters are used when the camera is mounted from the bottom (cable connects from the bottom i.e. partybot) as opposed to the standard top mounted camera (cable connects from the top i.e. base magni). If the camera is mounted from the bottom hFlip and vFlip should me set to true, otherwise it should be left on default i.e. false